### PR TITLE
change to post bid mode and new percentage pricing

### DIFF
--- a/README_Geojak.md
+++ b/README_Geojak.md
@@ -14,3 +14,5 @@
 14. made ah data crossfaction on the server "Turtle WoW" (all chars are considered horde)
 15. fixed a bug with the auto bid, bidding yoursefl up
 16. adjusted the auto pricing to not post items and instead pprint a warning if it things its not profitable
+17. percentage pricing, do 1g 10s 50% or 100% 50s which will calc a price as max( % * market_value, gold silver copper), the calc vlaue is then saved
+18. if you use the aux post bid mode, then clicking a buyout to undercut will not adjust the starting bid price aswell

--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -183,10 +183,19 @@ end
 function price_update()
     if selected_item then
         local historical_value = history.value(selected_item.key)
-        if get_bid_selection() or get_buyout_selection() then
-	        set_unit_start_price(undercut(get_bid_selection() or get_buyout_selection(), stack_size_slider:GetValue(), get_bid_selection()))
-	        unit_start_price_input:SetText(money.to_string(get_unit_start_price(), true, nil, nil, true))
-        end
+        
+		--in post bid mode only adjsut bid price when clickinga buyout to undercut
+		if aux.account_data.post_bid then
+			if get_bid_selection() then
+				set_unit_start_price(undercut(get_bid_selection(), stack_size_slider:GetValue(), get_bid_selection()))
+				unit_start_price_input:SetText(money.to_string(get_unit_start_price(), true, nil, nil, true))
+			end
+		else -- when not in post bid mode then seth both bid and buyout
+			if get_bid_selection() or get_buyout_selection() then
+				set_unit_start_price(undercut(get_bid_selection() or get_buyout_selection(), stack_size_slider:GetValue(), get_bid_selection()))
+				unit_start_price_input:SetText(money.to_string(get_unit_start_price(), true, nil, nil, true))
+			end
+		end
         if get_buyout_selection() then
 	        set_unit_buyout_price(undercut(get_buyout_selection(), stack_size_slider:GetValue()))
 	        unit_buyout_price_input:SetText(money.to_string(get_unit_buyout_price(), true, nil, nil, true))

--- a/tabs/post/frame.lua
+++ b/tabs/post/frame.lua
@@ -250,7 +250,7 @@ do
 	    end
     end)
     editbox.formatter = function() return money.to_string(get_unit_start_price(), true) end
-    editbox.char = function() set_bid_selection(); set_buyout_selection(); set_unit_start_price(money.from_string(this:GetText())) end
+    editbox.char = function() set_bid_selection(); set_buyout_selection(); set_unit_start_price(money.from_string(this:GetText(),selected_item.key)) end
     editbox.change = function() refresh = true end
     editbox.enter = function() this:ClearFocus() end
     editbox.focus_loss = function()
@@ -285,7 +285,7 @@ do
         end
     end)
     editbox.formatter = function() return money.to_string(get_unit_buyout_price(), true) end
-    editbox.char = function() set_buyout_selection(); set_unit_buyout_price(money.from_string(this:GetText())) end
+    editbox.char = function() set_buyout_selection(); set_unit_buyout_price(money.from_string(this:GetText(),selected_item.key)) end
     editbox.change = function() refresh = true end
     editbox.enter = function() this:ClearFocus() end
     editbox.focus_loss = function()


### PR DESCRIPTION
1. when in post bid mode then clicking a buyout price to undercut will only set buyout not both anymore, when post bid mode is disabled then it will still set both
2. allows percentage price input, e.g. "1g 50%" or "140% 75s" this will set the price to max (% * market_value, gold silver copper), the calc value is set. the value is not dynamically adjusted (yet)